### PR TITLE
Draft: add agent-plane capability patch fragment

### DIFF
--- a/capd/imagelab.capd.patch.yaml
+++ b/capd/imagelab.capd.patch.yaml
@@ -1,0 +1,11 @@
+# imagelab.capd.v0.yaml patch fragment
+contracts:
+  rpc_dir: "rpc"
+  schema_dir: "schemas"
+  session_dir: "sessions"
+  skill_dir: "skills"
+  memory_dir: "memory"
+validators:
+  executionDecision: "python -m validators.execution_decision"
+  skillManifest: "python -m validators.skill_manifest"
+  sessionReceipt: "python -m validators.session_receipt"

--- a/validators/__init__.py
+++ b/validators/__init__.py
@@ -1,0 +1,1 @@
+"""Validator entrypoints for imagelab capability contract checks."""

--- a/validators/execution_decision.py
+++ b/validators/execution_decision.py
@@ -1,0 +1,22 @@
+import json
+import sys
+from pathlib import Path
+
+EXPECTED_TYPE = 'ExecutionDecision'
+
+
+def main() -> int:
+    if len(sys.argv) < 2:
+        print('usage: python -m validators.execution_decision <json-file>', file=sys.stderr)
+        return 2
+    path = Path(sys.argv[1])
+    data = json.loads(path.read_text(encoding='utf-8'))
+    if data.get('type') != EXPECTED_TYPE:
+        print(f'expected type={EXPECTED_TYPE!r}, got {data.get("type")!r}', file=sys.stderr)
+        return 1
+    print(json.dumps({'ok': True, 'validated': EXPECTED_TYPE, 'path': str(path)}))
+    return 0
+
+
+if __name__ == '__main__':
+    raise SystemExit(main())

--- a/validators/session_receipt.py
+++ b/validators/session_receipt.py
@@ -1,0 +1,22 @@
+import json
+import sys
+from pathlib import Path
+
+EXPECTED_TYPE = 'SessionReceipt'
+
+
+def main() -> int:
+    if len(sys.argv) < 2:
+        print('usage: python -m validators.session_receipt <json-file>', file=sys.stderr)
+        return 2
+    path = Path(sys.argv[1])
+    data = json.loads(path.read_text(encoding='utf-8'))
+    if data.get('type') != EXPECTED_TYPE:
+        print(f'expected type={EXPECTED_TYPE!r}, got {data.get("type")!r}', file=sys.stderr)
+        return 1
+    print(json.dumps({'ok': True, 'validated': EXPECTED_TYPE, 'path': str(path)}))
+    return 0
+
+
+if __name__ == '__main__':
+    raise SystemExit(main())

--- a/validators/skill_manifest.py
+++ b/validators/skill_manifest.py
@@ -1,0 +1,22 @@
+import json
+import sys
+from pathlib import Path
+
+EXPECTED_TYPE = 'SkillManifest'
+
+
+def main() -> int:
+    if len(sys.argv) < 2:
+        print('usage: python -m validators.skill_manifest <json-file>', file=sys.stderr)
+        return 2
+    path = Path(sys.argv[1])
+    data = json.loads(path.read_text(encoding='utf-8'))
+    if data.get('type') != EXPECTED_TYPE:
+        print(f'expected type={EXPECTED_TYPE!r}, got {data.get("type")!r}', file=sys.stderr)
+        return 1
+    print(json.dumps({'ok': True, 'validated': EXPECTED_TYPE, 'path': str(path)}))
+    return 0
+
+
+if __name__ == '__main__':
+    raise SystemExit(main())


### PR DESCRIPTION
## What this lands

This draft PR adds an additive capability-descriptor patch fragment:
- `capd/imagelab.capd.patch.yaml`

## Why additive first

The current descriptor stays intact. This file captures the next contract directories and validator entrypoints needed once the new agent-plane schema family and receipts are accepted upstream.

## What it describes

- session / skill / memory contract directories
- validator entrypoints for `ExecutionDecision`, `SkillManifest`, and `SessionReceipt`

## Follow-up queue

1. Fold these fields into the canonical `imagelab.capd.v0.yaml` once the upstream spec family settles.
2. Add the actual validator modules under `validators/`.
3. Wire schema indexing and admission checks to the new agent-plane objects.

## Clean-room posture

This work is derived from public repo surfaces in our stack plus public reporting about Claude Code leak-era lessons. It does not copy proprietary Anthropic implementation details.
