### PR TITLE
chore(ci): harden supply chain — pin actions to SHA + least-privilege permissions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -2,12 +2,15 @@ name: validate
 on:
   push:
   pull_request:
+permissions:
+  contents: read
+
 jobs:
   validate:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version: "3.12"
       - name: Install strict-validation deps


### PR DESCRIPTION
Supply-chain + least-privilege hardening of CI.

- **Pin actions to full commit SHA** (with version comment) — floating `@vN` tags are a supply-chain injection vector.
- **Add `permissions: contents: read`** at the workflow level (least privilege for the default `GITHUB_TOKEN`).
- **Add `.github/dependabot.yml`** (github-actions, weekly) so the pins stay current.

Changed: .github/workflows/validate.yml +perms, .github/dependabot.yml (new)

🤖 Generated with [Claude Code](https://claude.com/claude-code)